### PR TITLE
Log IP of the real remote

### DIFF
--- a/ftw/jsonlog/subscribers.py
+++ b/ftw/jsonlog/subscribers.py
@@ -42,7 +42,7 @@ def collect_data_to_log(request):
 
     timestamp = datetime.now().isoformat()
     logdata = {
-        'host': request.environ.get('REMOTE_ADDR'),
+        'host': request.getClientAddr(),
         'user': get_username(request),
         'timestamp': timestamp,
         'method': request.method,


### PR DESCRIPTION
In a reverse proxy setup 'REMOTE_ADDR' will point to the IP of the reverse
proxy.