### PR TITLE
Change log suffix to -json.log (previously .json.log)

### DIFF
--- a/ftw/jsonlog/logger.py
+++ b/ftw/jsonlog/logger.py
@@ -26,7 +26,7 @@ def get_logfile_path():
     zconf = getConfiguration()
     handler_factories = zconf.eventlog.handler_factories
     eventlog_path = handler_factories[0].section.path
-    path = eventlog_path.replace('.log', '.json.log')
+    path = eventlog_path.replace('.log', '-json.log')
     return path
 
 


### PR DESCRIPTION
Since the logfile isn't really a JSON document, the use of the `.json` extension isn't really appropriate. We're therefore changing the logfile suffix to `-json.log`.