### PR TITLE
Include Plone site ID in logged infos.

### DIFF
--- a/ftw/jsonlog/subscribers.py
+++ b/ftw/jsonlog/subscribers.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from ftw.jsonlog.logger import setup_logger
 from threading import local
+from zope.component.hooks import getSite
 import json
 import logging
 import time
@@ -44,6 +45,7 @@ def collect_data_to_log(request):
 
     logdata = {
         'host': request.getClientAddr(),
+        'site': get_site_id(),
         'user': get_username(request),
         'timestamp': timing.timestamp,
         'method': request.method,
@@ -63,6 +65,13 @@ def get_content_length(request):
     content_length = request.response.getHeader('Content-Length')
     if content_length:
         return int(content_length)
+
+
+def get_site_id():
+    site = getSite()
+    if site:
+        return site.id
+    return ''
 
 
 def get_username(request):

--- a/ftw/jsonlog/tests/test_logging.py
+++ b/ftw/jsonlog/tests/test_logging.py
@@ -19,8 +19,8 @@ class TestLogging(FunctionalTestCase):
 
         log_entry = self.get_log_entries()[-1]
 
-        self.assertEquals(
-            [u'status', u'url', u'timestamp', u'bytes', u'host',
+        self.assertItemsEqual(
+            [u'status', u'url', u'timestamp', u'bytes', u'host', u'site',
              u'referer', u'user', u'duration', u'method', u'user_agent'],
             log_entry.keys())
 
@@ -38,6 +38,13 @@ class TestLogging(FunctionalTestCase):
         self.assertEquals(
             [u'2017-07-29T12:30:58.000750', u'2017-07-29T12:35:58.000750'],
             map(itemgetter('timestamp'), log_entries))
+
+    @browsing
+    def test_logs_plone_site_id(self, browser):
+        browser.open(self.portal)
+
+        log_entry = self.get_log_entries()[0]
+        self.assertEquals(u'plone', log_entry['site'])
 
     @browsing
     def test_logs_username_for_authenticated_user(self, browser):


### PR DESCRIPTION
Includes the Plone site ID in logged infos under the key `site`.

The site is fetched using the `getSite()` hook on every request. This should however be very inexpensive, since `getSite()` is just a simple [dotted attribute access on the module global `SiteInfo()` object](https://github.com/zopefoundation/zope.component/blob/14755dd5813656657405c49641e98357de4b706e/src/zope/component/hooks.py#L82-L83), and the Plone site ZODB object will pretty much be already cached or used later for every request.