### PR TITLE
Split data collection and serializing/logging data from event handling

### DIFF
--- a/ftw/structlog/collector.py
+++ b/ftw/structlog/collector.py
@@ -1,0 +1,58 @@
+from zope.component.hooks import getSite
+import time
+
+
+def collect_data_to_log(timing, request):
+    """Collect information to be logged, and return it as a Python dict.
+
+    Using the request and timing information, extract all necessary infos
+    that should be logged, and prepare them so they can be easily serialized.
+
+    ``timing`` is a module-global, thread-local object kept in
+    ftw.structlog.subscribers that is used to track request timing information.
+    """
+    duration = time.time() - timing.pub_start
+    timing.pub_start = None
+
+    request_data = {
+        'host': request.getClientAddr(),
+        'site': get_site_id(),
+        'user': get_username(request),
+        'timestamp': timing.timestamp,
+        'method': request.method,
+        'url': get_url(request),
+        'status': request.response.getStatus(),
+        'bytes': get_content_length(request),
+        'duration': duration,
+        # TODO: Always return empty string if no referrer
+        'referer': request.environ.get('HTTP_REFERER'),
+        'user_agent': request.environ.get('HTTP_USER_AGENT'),
+    }
+    return request_data
+
+
+def get_content_length(request):
+    content_length = request.response.getHeader('Content-Length')
+    if content_length:
+        return int(content_length)
+
+
+def get_site_id():
+    site = getSite()
+    if site:
+        return site.id
+    return ''
+
+
+def get_username(request):
+    user = request.get('AUTHENTICATED_USER')
+    if user:
+        return user.getUserName()
+
+
+def get_url(request):
+    url = request.get('ACTUAL_URL')
+    qs = request.get('QUERY_STRING')
+    if qs:
+        url = url + "?" + qs
+    return url

--- a/ftw/structlog/logger.py
+++ b/ftw/structlog/logger.py
@@ -1,6 +1,7 @@
 from App.config import getConfiguration
 from logging import FileHandler
 from logging import getLogger
+import json
 import logging
 
 
@@ -8,6 +9,10 @@ logger = getLogger('ftw.structlog')
 
 
 def setup_logger():
+    """Set up logger that writes to the JSON based logfile.
+
+    May be invoked multiple times, and must therefore be idempotent.
+    """
     if not logger.handlers:
         path = get_logfile_path()
         handler = FileHandler(path)
@@ -29,6 +34,15 @@ def get_logfile_path():
     assert eventlog_path.endswith('.log')
     path = eventlog_path.replace('.log', '-json.log')
     return path
+
+
+def log_request_data(request_data):
+    """Given a Python dict of key/value pairs to be logged, serialize and log
+    them to a JSON based logfile.
+    """
+    json_log = setup_logger()
+    msg = json.dumps(request_data, sort_keys=True)
+    json_log.info(msg)
 
 
 setup_logger()

--- a/ftw/structlog/subscribers.py
+++ b/ftw/structlog/subscribers.py
@@ -1,9 +1,8 @@
 from datetime import datetime
-from ftw.structlog.logger import setup_logger
+from ftw.structlog.collector import collect_data_to_log
+from ftw.structlog.logger import log_request_data
 from threading import local
 from tzlocal import get_localzone
-from zope.component.hooks import getSite
-import json
 import logging
 import pytz
 import time
@@ -11,7 +10,6 @@ import time
 
 LOG_TZ = get_localzone()
 
-json_log = setup_logger()
 root_logger = logging.root
 
 
@@ -22,15 +20,21 @@ timing.timestamp = None
 
 
 def handle_pub_start(event):
+    """Handle IPubStart events: Keep track of time when request started.
+    """
     global timing
     # Get time in UTC, make non-naive, and convert to local time for logging
     ts = datetime.utcnow().replace(tzinfo=pytz.utc)
     timing.timestamp = ts.astimezone(LOG_TZ).isoformat()
-
     timing.pub_start = time.time()
 
 
 def handle_pub_end(event):
+    """Handle IPubSuccess or IPubFailure events.
+
+    Log the request, being very careful not to cause any unhandled exceptions
+    as a side effect of logging.
+    """
     try:
         log_request(event)
     except Exception as exc:
@@ -38,58 +42,8 @@ def handle_pub_end(event):
 
 
 def log_request(event):
+    global timing
     request = event.request
 
-    logdata = collect_data_to_log(request)
-    msg = json.dumps(logdata, sort_keys=True)
-    json_log.info(msg)
-
-
-def collect_data_to_log(request):
-    global timing
-    duration = time.time() - timing.pub_start
-    timing.pub_start = None
-
-    logdata = {
-        'host': request.getClientAddr(),
-        'site': get_site_id(),
-        'user': get_username(request),
-        'timestamp': timing.timestamp,
-        'method': request.method,
-        'url': get_url(request),
-        'status': request.response.getStatus(),
-        'bytes': get_content_length(request),
-        'duration': duration,
-        # TODO: Always return empty string if no referrer
-        'referer': request.environ.get('HTTP_REFERER'),
-        'user_agent': request.environ.get('HTTP_USER_AGENT'),
-    }
-
-    return logdata
-
-
-def get_content_length(request):
-    content_length = request.response.getHeader('Content-Length')
-    if content_length:
-        return int(content_length)
-
-
-def get_site_id():
-    site = getSite()
-    if site:
-        return site.id
-    return ''
-
-
-def get_username(request):
-    user = request.get('AUTHENTICATED_USER')
-    if user:
-        return user.getUserName()
-
-
-def get_url(request):
-    url = request.get('ACTUAL_URL')
-    qs = request.get('QUERY_STRING')
-    if qs:
-        url = url + "?" + qs
-    return url
+    request_data = collect_data_to_log(timing, request)
+    log_request_data(request_data)


### PR DESCRIPTION
This is a **refactoring** to get a cleaner separation between handling of the `ZPublisher` events, and the rest of the work that's being done.

Previously everyting was stuffed into `subscribers.py`, which should really only be the entry point from which event handlers delegate to functions that collect data to be logged and serialize and write it to a logfile.