### PR TITLE
Fail gracefully if eventlog config can't be found

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,9 +86,10 @@ will be derived from the instance's eventlog path. If the instance's eventlog
 path is ``var/log/instance2.log``, the JSON logfile's path will be
 ``var/log/instance2-json.log``.
 
-Because ``ftw.structlog`` derives its logfile name from the eventlog path, an
-eventlog *must* be configured in ``zope.conf``, otherwise ``ftw.structlog``
-will prevent the instance from starting.
+**Note**: Because ``ftw.structlog`` derives its logfile name from the
+eventlog path, an eventlog *must* be configured in ``zope.conf``, otherwise
+``ftw.structlog`` will not log any requests and complain noisily through
+the root logger.
 
 Links
 -----

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fail gracefully if eventlog config can't be found in order to derive
+  log location from it. Instead of preventing instance startup, log a
+  noticeable error message using the root logger.
+  [lgraf]
 
 
 1.0.0 (2017-09-03)


### PR DESCRIPTION
Fail gracefully if eventlog config can't be found in order to derive log location from it. Instead of preventing instance startup, log a noticeable error message using the root logger.