### PR TITLE
Always log missing referer as empty string instead of null

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Always log missing referer as empty string instead of ``null``.
+  [lgraf]
 
 
 1.0.1 (2017-09-03)

--- a/ftw/structlog/collector.py
+++ b/ftw/structlog/collector.py
@@ -24,8 +24,7 @@ def collect_data_to_log(timing, request):
         'status': request.response.getStatus(),
         'bytes': get_content_length(request),
         'duration': duration,
-        # TODO: Always return empty string if no referrer
-        'referer': request.environ.get('HTTP_REFERER'),
+        'referer': request.environ.get('HTTP_REFERER', ''),
         'user_agent': request.environ.get('HTTP_USER_AGENT'),
     }
     return request_data

--- a/ftw/structlog/tests/test_logging.py
+++ b/ftw/structlog/tests/test_logging.py
@@ -151,7 +151,7 @@ class TestLogging(FunctionalTestCase):
         # First request, no referer
         browser.open(self.portal)
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(None, log_entry['referer'])
+        self.assertEquals(u'', log_entry['referer'])
 
         # Send referer with second request
         browser.open(view='@@ping', referer=True)


### PR DESCRIPTION
Always log missing referer as empty string instead of `null`. Makes sure the `referer` field is always of type `string`.