### PR TITLE
Deprecate `host` field, and introduce new `client_ip` field instead

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,7 @@ Example entry:
 
     {
       "bytes": 6875,
+      "cient_ip": "127.0.0.1",
       "duration": 0.30268411636353,
       "host": "127.0.0.1",
       "method": "GET",
@@ -52,11 +53,13 @@ The logged JSON entry contains the following data:
 +============+===============================================================+
 | bytes      | Size of response body in bytes (``Content-Length``)           |
 +------------+---------------------------------------------------------------+
+| client_ip  | Host where the request originated from (respecting            |
+|            | X-Forwarded-For)                                              |
++------------+---------------------------------------------------------------+
 | duration   | Time spent in ZPublisher to handle request (time between      |
 |            | ``IPubStart`` and ``IPubSuccess`` / ``IPubFailure`` )         |
 +------------+---------------------------------------------------------------+
-| host       | Host where the request originated from (respecting            |
-|            | X-Forwarded-For)                                              |
+| host       | Deprecated. You should use ``client_ip`` instead.             |
 +------------+---------------------------------------------------------------+
 | method     | HTTP request method                                           |
 +------------+---------------------------------------------------------------+

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,8 +2,12 @@ Changelog
 =========
 
 
-1.0.2 (unreleased)
+1.1.0 (unreleased)
 ------------------
+
+- DEPRECATED: The ``host`` field is deprecated. Instead, the newly introduced
+  ``client_ip`` field should be used to get the client's IP address.
+  [lgraf]
 
 - Always log missing referer as empty string instead of ``null``.
   [lgraf]

--- a/ftw/structlog/collector.py
+++ b/ftw/structlog/collector.py
@@ -15,7 +15,8 @@ def collect_data_to_log(timing, request):
     timing.pub_start = None
 
     request_data = {
-        'host': request.getClientAddr(),
+        'host': request.getClientAddr(),  # deprecated, client_ip should be used instead
+        'client_ip': request.getClientAddr(),
         'site': get_site_id(),
         'user': get_username(request),
         'timestamp': timing.timestamp,

--- a/ftw/structlog/tests/test_logging.py
+++ b/ftw/structlog/tests/test_logging.py
@@ -20,7 +20,7 @@ class TestLogging(FunctionalTestCase):
         log_entry = self.get_log_entries()[-1]
 
         self.assertItemsEqual(
-            [u'status', u'url', u'timestamp', u'bytes', u'host', u'site',
+            [u'status', u'url', u'timestamp', u'bytes', u'host', u'site', u'client_ip',
              u'referer', u'user', u'duration', u'method', u'user_agent'],
             log_entry.keys())
 
@@ -279,7 +279,7 @@ class TestLogging(FunctionalTestCase):
         # Standard source address
         browser.open(self.portal)
         log_entry = self.get_log_entries()[-1]
-        self.assertEqual('127.0.0.1', log_entry['host'])
+        self.assertEqual('127.0.0.1', log_entry['client_ip'])
 
     # Mac OS rejects source addresses other than 127.0.0.1 from the loopback
     # interface with "[Errno 49] Can't assign requested address"
@@ -291,4 +291,4 @@ class TestLogging(FunctionalTestCase):
 
         browser.open('http://localhost:%s/plone' % self.zserver_port)
         log_entry = self.get_log_entries()[-1]
-        self.assertEqual('127.0.0.42', log_entry['host'])
+        self.assertEqual('127.0.0.42', log_entry['client_ip'])

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.0.2.dev0'
+version = '1.1.0.dev0'
 
 tests_require = [
     'unittest2',


### PR DESCRIPTION
This is to avoid a **naming conflict** with the ELK stack, specifically filebeat. From version `6.3.x` onwards, filebeat enriches the events it reads with information about the host that filebeat is running on, and will write that metadata to the `host` field of the event (hardcoded).

This will overwrite any actual payload data in the event's `host` field.

See [Beats: Breaking changes in 6.3](https://www.elastic.co/guide/en/beats/libbeat/6.3/breaking-changes-6.3.html#breaking-changes-mapping-conflict) for some details on this change.

---

There are some ways to work around this, and change the filebeat configuration so that the event's own `host` field gets preserved, but with the inclusion of the `host` field in [ECS (Elastic Common Schema)](https://github.com/elastic/ecs/#host) it's quite likely that more conflicts around this field might arise in the future, especially if it's being used with a different type than defined in ECS (object vs. string).


With filebeat officially adding this to the [list of exported fields](https://www.elastic.co/guide/en/beats/filebeat/current/exported-fields-host-processor.html), it's also possible that components down the line (i.e., `logstash`) might be changed in a way where they rely on this field containing the actual host metadata.

Therefore we deprecate the `host` field in ftw.structlog, and introduce a new field `client_ip` with the same semantics that should be used instead.