### PR TITLE
Environment variable for muting eventlog setup errors.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,9 @@ eventlog path, an eventlog *must* be configured in ``zope.conf``, otherwise
 ``ftw.structlog`` will not log any requests and complain noisily through
 the root logger.
 
+When running tests in other projects, these errors can be muted by setting the
+environment variable ``FTW_STRUCTLOG_MUTE_SETUP_ERRORS=true``.
+
 Links
 -----
 

--- a/ftw/structlog/logger.py
+++ b/ftw/structlog/logger.py
@@ -3,6 +3,7 @@ from logging import FileHandler
 from logging import getLogger
 import json
 import logging
+import os
 
 
 logger = getLogger('ftw.structlog')
@@ -34,12 +35,13 @@ def get_logfile_path():
     zconf = getConfiguration()
     eventlog = getattr(zconf, 'eventlog', None)
     if eventlog is None:
-        root_logger.error('')
-        root_logger.error(
-            "ftw.structlog: Couldn't find eventlog configuration in order "
-            "to determine logfile location!")
-        root_logger.error("ftw.structlog: No request logfile will be written!")
-        root_logger.error('')
+        if os.environ.get('FTW_STRUCTLOG_MUTE_SETUP_ERRORS', '').lower().strip() != 'true':
+            root_logger.error('')
+            root_logger.error(
+                "ftw.structlog: Couldn't find eventlog configuration in order "
+                "to determine logfile location!")
+            root_logger.error("ftw.structlog: No request logfile will be written!")
+            root_logger.error('')
         return None
 
     handler_factories = eventlog.handler_factories

--- a/ftw/structlog/tests/test_logger_setup.py
+++ b/ftw/structlog/tests/test_logger_setup.py
@@ -1,0 +1,62 @@
+from contextlib import contextmanager
+from ftw.structlog.logger import setup_logger
+from StringIO import StringIO
+from unittest2 import TestCase
+import logging
+import os
+
+
+class TestSetupLogger(TestCase):
+
+    def testSetUp(self):
+        logger = logging.getLogger('ftw.structlog')
+        # If the functional tests are executed before these tests, the log handlers
+        # are already there and no setup happens.
+        map(logger.removeHandler, logger.handlers)
+
+    def test_logs_errors_when_eventlog_is_missing(self):
+        """
+        When the event log is missing in the zope configuration, ftw.structlog
+        noisily complains since it will result in missing log data.
+
+        In test setups we sometimes do not have an eventlog configured and we do not
+        care about ftw.structlog. In this situation we want to be able to mute the errors.
+        This can be done with an environment variable.
+        """
+
+        with self.expect_log_output(
+                "ftw.structlog: Couldn't find eventlog configuration in order to"
+                " determine logfile location!\n"
+                "ftw.structlog: No request logfile will be written!"):
+            setup_logger()
+
+        with self.expect_log_output(''):
+            with self.env_variable_set('FTW_STRUCTLOG_MUTE_SETUP_ERRORS', 'true'):
+                setup_logger()
+
+    @contextmanager
+    def expect_log_output(self, expected):
+        with self.captured_log() as output:
+            yield
+
+        self.assertEquals(expected.strip(), output.getvalue().strip())
+
+    @contextmanager
+    def captured_log(self):
+        output = StringIO()
+        handler = logging.StreamHandler(output)
+        logging.root.addHandler(handler)
+        try:
+            yield output
+        finally:
+            logging.root.removeHandler(handler)
+
+    @contextmanager
+    def env_variable_set(self, name, value):
+        assert name not in os.environ, \
+            'Unexpectedly found the variable {} in the environment.'.format(name)
+        os.environ[name] = value
+        try:
+            yield
+        finally:
+            os.environ.pop(name)


### PR DESCRIPTION
When running tests of other projects there is usually no eventlog configured. ftw.structlog then spams the test output.

For muting the setup errors in this situation an environment variable is introduced. The variable is only meant to be used in testing since we want to see the errors in production.