### PR TITLE
Use older release of "freezegun".

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ tests_require = [
     'ftw.testbrowser',
     'requests_toolbelt',
     'plone.rest',
-    'freezegun',
+    'freezegun < 0.3.15',
 ]
 
 


### PR DESCRIPTION
Our tests are failinng due to a bug in "freezegun" 0.3.15.

"freezegun" 0.3.15 uses "dateutil" in an incompatible way (see https://github.com/spulec/freezegun/compare/0.3.14...0.3.15). The issue has already been reported in the GitHub repository of "freezegun" (see https://github.com/spulec/freezegun/issues/335). Until the bug is fixed in "freezegun", we use an older release of it.