### PR TITLE
Log view name for things we consider a view.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,8 @@ Example entry:
       "timestamp": "2017-07-29T12:30:58.000750+02:00",
       "url": "http:\/\/localhost:8080\/plone\/my-page",
       "user": "john.doe",
-      "user_agent": "Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/60.0.3112.113 Safari\/537.36"
+      "user_agent": "Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/60.0.3112.113 Safari\/537.36",
+      "view": "some_view"
     }
 
 
@@ -79,6 +80,8 @@ The logged JSON entry contains the following data:
 +------------+---------------------------------------------------------------+
 | user_agent | User-Agent                                                    |
 +------------+---------------------------------------------------------------+
+| view       | Name of the browser view or REST API endpoint  (see below)    |
++------------+---------------------------------------------------------------+
 
 
 If ``SQLAlchemy`` is installed and integrated via ``z3c.saconfig``, SQL query
@@ -108,6 +111,44 @@ the root logger.
 
 When running tests in other projects, these errors can be muted by setting the
 environment variable ``FTW_STRUCTLOG_MUTE_SETUP_ERRORS=true``.
+
+View Name
+---------
+
+An attempt is made to log the name of the invoked browser view or REST API
+endpoint, so that requests to particular views can easily be grouped without
+having to resort to URL string parsing.
+
+However, this is intentionally limited, and aims to only handle the most
+common and useful cases. It's also implemented in a way to not fill up logs
+with too many diverse values for ``view``, by grouping together very
+common requests (CSS and JS assets) under common names.
+
+The following table gives an example of how names of different "views" are
+logged:
+
++-------------------------------------------------+----------------------+
+| View Type                                       | view                 |
++=================================================+======================+
+| Regular browser view                            | 'some_view'          |
++-------------------------------------------------+----------------------+
+| Regular browser view, published attributes      | 'some_view/attr'     |
++-------------------------------------------------+----------------------+
+| plone.rest named services                       | '@actions'           |
++-------------------------------------------------+----------------------+
+| plone.rest named services with path params      | '@users'             |
++-------------------------------------------------+----------------------+
+| plone.rest unnamed GET/POST/...                 | 'context'            |
++-------------------------------------------------+----------------------+
+| CSS                                             | 'portal_css'         |
++-------------------------------------------------+----------------------+
+| JS                                              | 'portal_javascripts' |
++-------------------------------------------------+----------------------+
+| Resources                                       | '++resource++'        |
++-------------------------------------------------+----------------------+
+| Theme resources                                 | '++theme++'           |
++-------------------------------------------------+----------------------+
+
 
 Links
 -----

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,11 @@ Changelog
 =========
 
 
-1.2.1 (unreleased)
+1.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Log view name for browser views and REST API services.
+  [deiferni, lukasg]
 
 
 1.2.0 (2020-05-19)

--- a/ftw/structlog/collector.py
+++ b/ftw/structlog/collector.py
@@ -1,6 +1,24 @@
+from inspect import ismethod
 from zope.annotation import IAnnotations
 from zope.component.hooks import getSite
+from zope.interface import Interface
+from zope.publisher.interfaces.browser import IBrowserView
 import time
+
+
+try:
+    from plone.rest.interfaces import IService
+except ImportError:
+    class IService(Interface):
+        pass
+
+
+VIEW_GROUP_MARKERS = [
+    '++resource++',
+    '++theme++',
+    'portal_css',
+    'portal_javascripts',
+]
 
 
 def collect_data_to_log(timing, request):
@@ -15,6 +33,11 @@ def collect_data_to_log(timing, request):
     duration = time.time() - timing.pub_start
     timing.pub_start = None
 
+    try:
+        view_name = get_view_name(request)
+    except Exception:
+        view_name = None
+
     request_data = {
         'host': request.getClientAddr(),  # deprecated, client_ip should be used instead
         'client_ip': request.getClientAddr(),
@@ -28,6 +51,7 @@ def collect_data_to_log(timing, request):
         'duration': duration,
         'referer': request.environ.get('HTTP_REFERER', ''),
         'user_agent': request.environ.get('HTTP_USER_AGENT'),
+        'view': view_name,
     }
 
     sql_query_time = IAnnotations(request).get('sql_query_time')
@@ -62,3 +86,57 @@ def get_url(request):
     if qs:
         url = url + "?" + qs
     return url
+
+
+def canonicalize_browserview_name(view_name):
+    if view_name.startswith('@@'):
+        return view_name[2:]
+    return view_name
+
+
+def get_view_name(request):
+    path = request['PATH_INFO']
+
+    # Short circuit certain common view groups early, and consolidate them
+    # under a group name (mainly CSS and JS resources).
+    #
+    # We don't want to log each individual resource name, since that would
+    # blow up the range of possible values for the view name with highly
+    # dynamic data, and would negatively affect compression or indexing of
+    # these logs in ES.
+    for marker in VIEW_GROUP_MARKERS:
+        if marker in path:
+            return marker
+
+    published = request.get('PUBLISHED')
+
+    # plone.rest service
+    if IService.providedBy(published):
+        service = published
+        # GET_application_json_@named-service
+        full_service_name = str(service.__name__)
+        service_name = full_service_name.replace(request._rest_service_id, '')
+
+        # Unnamed service
+        if service_name == '':
+            return 'context'
+
+        return service_name
+
+    if ismethod(published):
+        # Handle methods on views published via allowed_attributes.
+        parents = request.get('PARENTS')
+        if parents and IBrowserView.providedBy(parents[0]):
+            view_name = '/'.join(request.steps[-2:])
+            return canonicalize_browserview_name(view_name)
+
+    if request.steps:
+        # Fall back to looking at the the rightmost path segment
+        view_name = request.steps[-1]
+
+        # Probably a legacy publishing mechanism, like DTML templates.
+        # Don't attempt to resolve any further.
+        if view_name == 'index_html':
+            return None
+
+        return canonicalize_browserview_name(view_name)

--- a/ftw/structlog/demo/configure.zcml
+++ b/ftw/structlog/demo/configure.zcml
@@ -11,6 +11,7 @@
         name="ping"
         class=".views.Ping"
         permission="zope.Public"
+        allowed_attributes="some_method"
         />
 
     <browser:page
@@ -40,6 +41,14 @@
         class=".views.SendHundredBytes"
         permission="zope.Public"
         />
+
+    <plone:service
+        method="GET"
+        for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+        factory=".views.RESTEndpoint"
+        accept='application/json'
+        permission="zope.Public"
+      />
 
     <plone:service
         method="PUT"

--- a/ftw/structlog/demo/views.py
+++ b/ftw/structlog/demo/views.py
@@ -8,6 +8,10 @@ class Ping(BrowserView):
     def __call__(self):
         return 'pong'
 
+    def some_method(self):
+        """Docstring to allow publishing"""
+        return 'pong from method'
+
 
 class InternalServerError(BrowserView):
 

--- a/ftw/structlog/testing.py
+++ b/ftw/structlog/testing.py
@@ -3,6 +3,8 @@ from ftw.testbrowser import REQUESTS_BROWSER_FIXTURE
 from logging import getLogger
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
 from plone.testing import z2
 from StringIO import StringIO
 from zope.configuration import xmlconfig
@@ -111,6 +113,9 @@ class StructLogLayer(PloneSandboxLayer):
             '  <include package="ftw.structlog.demo" />'
             '</configure>',
             context=configurationContext)
+
+    def setUpPloneSite(self, portal):
+        setRoles(portal, TEST_USER_ID, ['Manager'])
 
     def tearDownZope(self, app):
         self.remove_eventlog()

--- a/ftw/structlog/tests/test_logger_setup.py
+++ b/ftw/structlog/tests/test_logger_setup.py
@@ -39,7 +39,7 @@ class TestSetupLogger(TestCase):
         with self.captured_log() as output:
             yield
 
-        self.assertEquals(expected.strip(), output.getvalue().strip())
+        self.assertEqual(expected.strip(), output.getvalue().strip())
 
     @contextmanager
     def captured_log(self):

--- a/ftw/structlog/tests/test_logging.py
+++ b/ftw/structlog/tests/test_logging.py
@@ -48,8 +48,8 @@ class TestLogging(FunctionalTestCase):
 
         log_entries = self.get_log_entries()
 
-        self.assertEquals(2, len(log_entries))
-        self.assertEquals(
+        self.assertEqual(2, len(log_entries))
+        self.assertEqual(
             [u'2017-07-29T12:30:58.000750+02:00',
              u'2017-07-29T12:35:58.000750+02:00'],
             map(itemgetter('timestamp'), log_entries))
@@ -59,7 +59,7 @@ class TestLogging(FunctionalTestCase):
         browser.open(self.portal)
 
         log_entry = self.get_log_entries()[0]
-        self.assertEquals(u'plone', log_entry['site'])
+        self.assertEqual(u'plone', log_entry['site'])
 
     @browsing
     def test_logs_username_for_authenticated_user(self, browser):
@@ -67,14 +67,14 @@ class TestLogging(FunctionalTestCase):
         browser.open(self.portal)
 
         log_entry = self.get_log_entries()[0]
-        self.assertEquals(TEST_USER_NAME, log_entry['user'])
+        self.assertEqual(TEST_USER_NAME, log_entry['user'])
 
     @browsing
     def test_logs_username_for_anonymous(self, browser):
         browser.open(self.portal)
 
         log_entry = self.get_log_entries()[0]
-        self.assertEquals(u'Anonymous User', log_entry['user'])
+        self.assertEqual(u'Anonymous User', log_entry['user'])
 
     @browsing
     def test_logs_request_methods(self, browser):
@@ -82,31 +82,31 @@ class TestLogging(FunctionalTestCase):
 
         browser.open(view='@@ping')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'GET', log_entry['method'])
+        self.assertEqual(u'GET', log_entry['method'])
 
         browser.open(view='@@ping', method='POST')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'POST', log_entry['method'])
+        self.assertEqual(u'POST', log_entry['method'])
 
         browser.open(view='@rest-endpoint', method='PUT',
                      headers={'Accept': 'application/json'})
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'PUT', log_entry['method'])
+        self.assertEqual(u'PUT', log_entry['method'])
 
         browser.open(view='@rest-endpoint', method='PATCH',
                      headers={'Accept': 'application/json'})
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'PATCH', log_entry['method'])
+        self.assertEqual(u'PATCH', log_entry['method'])
 
         browser.open(view='@rest-endpoint', method='DELETE',
                      headers={'Accept': 'application/json'})
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'DELETE', log_entry['method'])
+        self.assertEqual(u'DELETE', log_entry['method'])
 
         browser.open(view='@rest-endpoint', method='HEAD',
                      headers={'Accept': 'application/json'})
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'HEAD', log_entry['method'])
+        self.assertEqual(u'HEAD', log_entry['method'])
 
     @browsing
     def test_logs_url(self, browser):
@@ -114,7 +114,7 @@ class TestLogging(FunctionalTestCase):
 
         browser.open(view='@@ping')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(
+        self.assertEqual(
             u'http://localhost:%s/plone/@@ping' % self.zserver_port,
             log_entry['url'])
 
@@ -124,7 +124,7 @@ class TestLogging(FunctionalTestCase):
 
         browser.open(view='@@ping?foo=bar')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(
+        self.assertEqual(
             u'http://localhost:%s/plone/@@ping?foo=bar' % self.zserver_port,
             log_entry['url'])
 
@@ -135,23 +135,23 @@ class TestLogging(FunctionalTestCase):
 
         browser.open(view='@@ping')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(200, log_entry['status'])
+        self.assertEqual(200, log_entry['status'])
 
         browser.open(view='@@internal-server-error')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(500, log_entry['status'])
+        self.assertEqual(500, log_entry['status'])
 
         browser.open(view='@@unauthorized')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(401, log_entry['status'])
+        self.assertEqual(401, log_entry['status'])
 
         browser.open(view='@@redirect')
         log_entry = self.get_log_entries()[-2]
-        self.assertEquals(302, log_entry['status'])
+        self.assertEqual(302, log_entry['status'])
 
         browser.open(view='@@doesnt-exist')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(404, log_entry['status'])
+        self.assertEqual(404, log_entry['status'])
 
     @browsing
     def test_logs_referer(self, browser):
@@ -160,12 +160,12 @@ class TestLogging(FunctionalTestCase):
         # First request, no referer
         browser.open(self.portal)
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'', log_entry['referer'])
+        self.assertEqual(u'', log_entry['referer'])
 
         # Send referer with second request
         browser.open(view='@@ping', referer=True)
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(
+        self.assertEqual(
             u'http://localhost:%s/plone' % self.zserver_port,
             log_entry['referer'])
 
@@ -181,7 +181,7 @@ class TestLogging(FunctionalTestCase):
         # Custom user agent
         browser.open(self.portal, headers={'User-Agent': 'foobar/3.1415'})
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals('foobar/3.1415', log_entry['user_agent'])
+        self.assertEqual('foobar/3.1415', log_entry['user_agent'])
 
     @browsing
     def test_logs_timestamp(self, browser):
@@ -279,7 +279,7 @@ class TestLogging(FunctionalTestCase):
         browser.open(self.portal, view='send-100-bytes')
 
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(100, log_entry['bytes'])
+        self.assertEqual(100, log_entry['bytes'])
 
     @browsing
     def test_logs_standard_source_address(self, browser):
@@ -296,15 +296,15 @@ class TestLogging(FunctionalTestCase):
 
         browser.open(self.portal, view='manage_main')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'manage_main', log_entry['view'])
+        self.assertEqual(u'manage_main', log_entry['view'])
 
         browser.open(self.portal, view='/portal_catalog/manage_catalogIndexes')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'manage_catalogIndexes', log_entry['view'])
+        self.assertEqual(u'manage_catalogIndexes', log_entry['view'])
 
         browser.open(self.portal, view='edit')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'site-controlpanel', log_entry['view'])
+        self.assertEqual(u'site-controlpanel', log_entry['view'])
 
     @browsing
     def test_logs_view_when_calling_add_view(self, browser):
@@ -313,27 +313,27 @@ class TestLogging(FunctionalTestCase):
         browser.open(self.portal)
         factoriesmenu.add('Folder')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'portal_factory', log_entry['view'])
+        self.assertEqual(u'portal_factory', log_entry['view'])
 
         browser.fill({'Title': 'foo'}).submit()
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'folder_listing', log_entry['view'])
+        self.assertEqual(u'folder_listing', log_entry['view'])
 
         browser.click_on('Edit')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'atct_edit', log_entry['view'])
+        self.assertEqual(u'atct_edit', log_entry['view'])
 
         browser.fill({'Title': 'bar'}).submit()
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'folder_listing', log_entry['view'])
+        self.assertEqual(u'folder_listing', log_entry['view'])
 
         browser.click_on('Sharing')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'sharing', log_entry['view'])
+        self.assertEqual(u'sharing', log_entry['view'])
 
         browser.click_on('Contents')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'folder_contents', log_entry['view'])
+        self.assertEqual(u'folder_contents', log_entry['view'])
 
     @browsing
     def test_logs_view_when_calling_browser_views(self, browser):
@@ -341,11 +341,11 @@ class TestLogging(FunctionalTestCase):
 
         browser.open(view='@@ping')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'ping', log_entry['view'])
+        self.assertEqual(u'ping', log_entry['view'])
 
         browser.open(view='ping')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'ping', log_entry['view'])
+        self.assertEqual(u'ping', log_entry['view'])
 
     @browsing
     def test_logs_view_when_calling_published_attributes(self, browser):
@@ -353,7 +353,7 @@ class TestLogging(FunctionalTestCase):
 
         browser.open(view='ping/some_method')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'ping/some_method', log_entry['view'])
+        self.assertEqual(u'ping/some_method', log_entry['view'])
 
     @browsing
     def test_logs_view_when_calling_rest_endpoints(self, browser):
@@ -362,25 +362,25 @@ class TestLogging(FunctionalTestCase):
         browser.open(view='@rest-endpoint', method='PUT',
                      headers={'Accept': 'application/json'})
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'@rest-endpoint',
+        self.assertEqual(u'@rest-endpoint',
                           log_entry['view'])
 
         browser.open(view='@rest-endpoint', method='PATCH',
                      headers={'Accept': 'application/json'})
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'@rest-endpoint',
+        self.assertEqual(u'@rest-endpoint',
                           log_entry['view'])
 
         browser.open(view='@rest-endpoint', method='DELETE',
                      headers={'Accept': 'application/json'})
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'@rest-endpoint',
+        self.assertEqual(u'@rest-endpoint',
                           log_entry['view'])
 
         browser.open(view='@rest-endpoint', method='HEAD',
                      headers={'Accept': 'application/json'})
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'@rest-endpoint',
+        self.assertEqual(u'@rest-endpoint',
                           log_entry['view'])
 
     @browsing
@@ -390,7 +390,7 @@ class TestLogging(FunctionalTestCase):
         browser.open(self.portal, method='GET',
                      headers={'Accept': 'application/json'})
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'context',
+        self.assertEqual(u'context',
                           log_entry['view'])
 
     @browsing
@@ -401,19 +401,19 @@ class TestLogging(FunctionalTestCase):
 
         browser.open(self.portal.absolute_url() + '/portal_css/some.css')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'portal_css', log_entry['view'])
+        self.assertEqual(u'portal_css', log_entry['view'])
 
         browser.open(self.portal.absolute_url() + '/portal_javascripts/some.js')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'portal_javascripts', log_entry['view'])
+        self.assertEqual(u'portal_javascripts', log_entry['view'])
 
         browser.open(self.portal.absolute_url() + '/++resource++/some.js')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'++resource++', log_entry['view'])
+        self.assertEqual(u'++resource++', log_entry['view'])
 
         browser.open(self.portal.absolute_url() + '/++theme++/some.css')
         log_entry = self.get_log_entries()[-1]
-        self.assertEquals(u'++theme++', log_entry['view'])
+        self.assertEqual(u'++theme++', log_entry['view'])
 
     # Mac OS rejects source addresses other than 127.0.0.1 from the loopback
     # interface with "[Errno 49] Can't assign requested address"

--- a/ftw/structlog/tests/test_logging.py
+++ b/ftw/structlog/tests/test_logging.py
@@ -3,6 +3,7 @@ from freezegun import freeze_time
 from ftw.structlog.testing import PatchedLogTZ
 from ftw.structlog.tests import FunctionalTestCase
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
 from operator import itemgetter
 from plone.app.testing import TEST_USER_NAME
 from requests_toolbelt.adapters.source import SourceAddressAdapter
@@ -29,7 +30,7 @@ class TestLogging(FunctionalTestCase):
 
         self.assertItemsEqual(
             [u'status', u'url', u'timestamp', u'bytes', u'host', u'site', u'client_ip',
-             u'referer', u'user', u'duration', u'method', u'user_agent'],
+             u'referer', u'user', u'duration', u'method', u'user_agent', u'view'],
             log_entry.keys())
 
     @browsing
@@ -288,6 +289,131 @@ class TestLogging(FunctionalTestCase):
         browser.open(self.portal)
         log_entry = self.get_log_entries()[-1]
         self.assertEqual('127.0.0.1', log_entry['client_ip'])
+
+    @browsing
+    def test_logs_view_in_management_views(self, browser):
+        browser.login()
+
+        browser.open(self.portal, view='manage_main')
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'manage_main', log_entry['view'])
+
+        browser.open(self.portal, view='/portal_catalog/manage_catalogIndexes')
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'manage_catalogIndexes', log_entry['view'])
+
+        browser.open(self.portal, view='edit')
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'site-controlpanel', log_entry['view'])
+
+    @browsing
+    def test_logs_view_when_calling_add_view(self, browser):
+        browser.login()
+
+        browser.open(self.portal)
+        factoriesmenu.add('Folder')
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'portal_factory', log_entry['view'])
+
+        browser.fill({'Title': 'foo'}).submit()
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'folder_listing', log_entry['view'])
+
+        browser.click_on('Edit')
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'atct_edit', log_entry['view'])
+
+        browser.fill({'Title': 'bar'}).submit()
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'folder_listing', log_entry['view'])
+
+        browser.click_on('Sharing')
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'sharing', log_entry['view'])
+
+        browser.click_on('Contents')
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'folder_contents', log_entry['view'])
+
+    @browsing
+    def test_logs_view_when_calling_browser_views(self, browser):
+        browser.login()
+
+        browser.open(view='@@ping')
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'ping', log_entry['view'])
+
+        browser.open(view='ping')
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'ping', log_entry['view'])
+
+    @browsing
+    def test_logs_view_when_calling_published_attributes(self, browser):
+        browser.login()
+
+        browser.open(view='ping/some_method')
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'ping/some_method', log_entry['view'])
+
+    @browsing
+    def test_logs_view_when_calling_rest_endpoints(self, browser):
+        browser.login()
+
+        browser.open(view='@rest-endpoint', method='PUT',
+                     headers={'Accept': 'application/json'})
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'@rest-endpoint',
+                          log_entry['view'])
+
+        browser.open(view='@rest-endpoint', method='PATCH',
+                     headers={'Accept': 'application/json'})
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'@rest-endpoint',
+                          log_entry['view'])
+
+        browser.open(view='@rest-endpoint', method='DELETE',
+                     headers={'Accept': 'application/json'})
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'@rest-endpoint',
+                          log_entry['view'])
+
+        browser.open(view='@rest-endpoint', method='HEAD',
+                     headers={'Accept': 'application/json'})
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'@rest-endpoint',
+                          log_entry['view'])
+
+    @browsing
+    def test_logs_view_for_unnamed_rest_endpoint(self, browser):
+        browser.login()
+
+        browser.open(self.portal, method='GET',
+                     headers={'Accept': 'application/json'})
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'context',
+                          log_entry['view'])
+
+    @browsing
+    def test_logs_view_for_asset_requests(self, browser):
+        browser.login()
+
+        browser.raise_http_errors = False
+
+        browser.open(self.portal.absolute_url() + '/portal_css/some.css')
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'portal_css', log_entry['view'])
+
+        browser.open(self.portal.absolute_url() + '/portal_javascripts/some.js')
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'portal_javascripts', log_entry['view'])
+
+        browser.open(self.portal.absolute_url() + '/++resource++/some.js')
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'++resource++', log_entry['view'])
+
+        browser.open(self.portal.absolute_url() + '/++theme++/some.css')
+        log_entry = self.get_log_entries()[-1]
+        self.assertEquals(u'++theme++', log_entry['view'])
 
     # Mac OS rejects source addresses other than 127.0.0.1 from the loopback
     # interface with "[Errno 49] Can't assign requested address"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.2.1.dev0'
+version = '1.3.0.dev0'
 
 tests_require = [
     'unittest2',
@@ -9,6 +9,7 @@ tests_require = [
     'ftw.testbrowser',
     'requests_toolbelt',
     'plone.rest',
+    'Plone',
     'freezegun < 0.3.15',
 ]
 


### PR DESCRIPTION
I've chosen to rely on introspection rather than attempting to program something magic with the request path. That way we can explicitly handle certain things, and fall back to a default for others based on the actually published object.

Turns out there is a lot of arcane stuff around that doesn't nicely provide an interface we could check against. For example `FSControllerPythonScript`, `DTMLFile`, `FSDTMLMethod`,
`FSControllerPageTemplate`, `PythonScript` to name a few. They all provide an `id` however, this seems to be either an attribute or a callable. I have implemented a working duck-typing based solution. I'm unsure if this is a sane approach or if instead we should just choose to not log the `view_name` in such a case.

In any case i've added some extra paranoia to make sure we don't run into issues while attempting to get the id and that we don't serialize any unserializables to json. In such a case the `view_name` is gracefully set to `None`.

I've added extensive testing by hitting various things on the plone site and by creating content during test. To be able to do so i had to make the test-user a `Manager`.

@lukasgraf i'm handing this over to you hoping it is useful to finish the issue. Please feel free to hijack and modify according to your preferences 😄. 

https://4teamwork.atlassian.net/browse/GEVER-234

----

I actually turned this on its head quite a bit: [lukasg]

- I simplified it by simply not dealing with any legacy publishing mechanisms like DTML or or other stuff found in ZMI, which we really don't care about for performance analysis
- I made sure to also handle methods published via `allowed_attributed`, like `tabbed_view/listing`,
- I normalized `plone.rest` named service names
- I wrapped the entire view name extraction logic in a `try..except`, because there's lots of unexpected edge cases and we don't want logging of the rest of the request to fail, even if the view name can't be determined

The following table gives an example of how names of different "views"
are logged:

| View Type                                  | view\_name            |
| ------------------------------------------ | --------------------- |
| Regular browser view                       | `'some_view'`          |
| Regular browser view, published attributes | `'some_view/attr'`     |
| plone.rest named services                  | `'@actions'`            |
| plone.rest named services with path params | `'@users'`              |
| plone.rest unnamed GET/POST/...            | `'context'`             |
| CSS                                        | `'portal\_css'`         |
| JS                                         | `'portal\_javascripts'` |
| Resources                                  | `'\++resource++'`        |
| Theme resources                            | `'\++theme++'`           |
