### PR TITLE
Track query execution time if SQLAlchemy is present

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,18 @@ The logged JSON entry contains the following data:
 +------------+---------------------------------------------------------------+
 
 
+If ``SQLAlchemy`` is installed and integrated via ``z3c.saconfig``, SQL query
+times will also be logged. For requests that perform SQL queries, there will
+be an additional key ``sql_query_time`` containing the cumulative time of
+all SQL queries during that request:
+
++----------------+----------------------------------------------------------------+
+| key            | value                                                          |
++================+================================================================+
+| sql_query_time | Cumulative time of all SQL queries during request (in seconds) |
++----------------+----------------------------------------------------------------+
+
+
 Logfile Location
 ----------------
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,10 @@ Changelog
 =========
 
 
-1.1.1 (unreleased)
+1.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Track query execution time if SQLAlchemy is present. [lgraf]
 
 
 1.1.0 (2019-01-11)

--- a/ftw/structlog/collector.py
+++ b/ftw/structlog/collector.py
@@ -1,3 +1,4 @@
+from zope.annotation import IAnnotations
 from zope.component.hooks import getSite
 import time
 
@@ -28,6 +29,11 @@ def collect_data_to_log(timing, request):
         'referer': request.environ.get('HTTP_REFERER', ''),
         'user_agent': request.environ.get('HTTP_USER_AGENT'),
     }
+
+    sql_query_time = IAnnotations(request).get('sql_query_time')
+    if sql_query_time:
+        request_data['sql_query_time'] = sql_query_time
+
     return request_data
 
 

--- a/ftw/structlog/configure.zcml
+++ b/ftw/structlog/configure.zcml
@@ -1,5 +1,6 @@
 <configure
-    xmlns="http://namespaces.zope.org/zope">
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
 
   <subscriber
       for="ZPublisher.interfaces.IPubStart"
@@ -15,5 +16,12 @@
       for="ZPublisher.interfaces.IPubFailure"
       handler=".subscribers.handle_pub_end"
       />
+
+    <configure zcml:condition="installed z3c.saconfig">
+      <subscriber
+          for="z3c.saconfig.interfaces.IEngineCreatedEvent"
+          handler=".sqltime.register_query_profiling_listeners"
+          />
+    </configure>
 
 </configure>

--- a/ftw/structlog/demo/configure.zcml
+++ b/ftw/structlog/demo/configure.zcml
@@ -3,6 +3,7 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.structlog.demo">
 
     <browser:page
@@ -75,5 +76,21 @@
         name='@rest-endpoint'
         permission="zope.Public"
       />
+
+    <configure zcml:condition="installed z3c.saconfig"
+               xmlns:db="http://namespaces.zope.org/db">
+
+        <include package="z3c.saconfig" file="meta.zcml" />
+        <db:engine name="test.db" url="sqlite:///:memory:" />
+        <db:session name="testing" engine="test.db" />
+
+        <browser:page
+            for="*"
+            name="run-sql-query"
+            class=".views.SQLQueryView"
+            permission="zope.Public"
+            />
+
+    </configure>
 
 </configure>

--- a/ftw/structlog/demo/views.py
+++ b/ftw/structlog/demo/views.py
@@ -39,3 +39,12 @@ class RESTEndpoint(Service):
     def render(self):
         self.request.response.setHeader("Content-Type", "application/json")
         return json.dumps({'status': 'ok'})
+
+
+class SQLQueryView(BrowserView):
+
+    def __call__(self):
+        from z3c.saconfig import named_scoped_session
+        session = named_scoped_session('testing')()
+        result = session.execute('SELECT 1')
+        return result.scalar()

--- a/ftw/structlog/sqltime.py
+++ b/ftw/structlog/sqltime.py
@@ -1,0 +1,38 @@
+from sqlalchemy.event import listen
+from zope.annotation import IAnnotations
+from zope.globalrequest import getRequest
+import time
+
+
+def before_cursor_execute(conn, cursor, statement,
+                          parameters, context, executemany):
+    conn.info.setdefault('query_start_time', []).append(time.time())
+
+
+def after_cursor_execute(conn, cursor, statement,
+                         parameters, context, executemany):
+    if 'query_start_time' not in conn.info:
+        return
+
+    if len(conn.info['query_start_time']) > 1:
+        # Ignore any inner queries (in case of nested cursor execute events)
+        conn.info['query_start_time'].pop(-1)
+        return
+
+    query_time = time.time() - conn.info['query_start_time'].pop(-1)
+
+    # Track cumulative query execution time in request annotations,
+    # for it to be collected later when logging the request.
+    ann = IAnnotations(getRequest())
+    ann['sql_query_time'] = ann.get('sql_query_time', 0) + query_time
+
+
+def register_query_profiling_listeners(event):
+    """Register event listeners to track query execution time.
+
+    Based on https://docs.sqlalchemy.org/en/13/faq/performance.html#query-profiling
+    """
+    engine = event.engine
+
+    listen(engine, 'before_cursor_execute', before_cursor_execute)
+    listen(engine, 'after_cursor_execute', after_cursor_execute)

--- a/ftw/structlog/testing.py
+++ b/ftw/structlog/testing.py
@@ -16,8 +16,9 @@ def get_log_path():
     """Get filesystem path to ftw.structlog's logfile.
     """
     logger = getLogger('ftw.structlog')
-    log_path = logger.handlers[0].stream.name
-    return log_path
+    if logger.handlers:
+        log_path = logger.handlers[0].stream.name
+        return log_path
 
 
 class PatchedLogTZ(object):
@@ -116,8 +117,10 @@ class StructLogLayer(PloneSandboxLayer):
 
     def testTearDown(self):
         # Isolation: truncate ftw.structlog's logfile after each test
-        with open(get_log_path(), 'w') as f:
-            f.truncate()
+        log_path = get_log_path()
+        if log_path and os.path.isfile(log_path):
+            with open(log_path, 'w') as f:
+                f.truncate()
 
 
 STRUCTLOG_FIXTURE = StructLogLayer()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.1.1.dev0'
+version = '1.2.0.dev0'
 
 tests_require = [
     'unittest2',

--- a/test-plone-4.3.x-sqlalchemy.cfg
+++ b/test-plone-4.3.x-sqlalchemy.cfg
@@ -1,0 +1,16 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+
+package-name = ftw.structlog
+
+[test]
+eggs +=
+    z3c.saconfig
+    SQLAlchemy
+    zope.sqlalchemy
+
+[versions]
+z3c.saconfig = 0.14
+SQLAlchemy = 1.1.18
+zope.sqlalchemy = 0.7.7


### PR DESCRIPTION
If ``SQLAlchemy`` is installed and integrated via ``z3c.saconfig``, SQL query times will also be logged. For requests that perform SQL queries, there will be an additional key ``sql_query_time`` containing the cumulative time of all SQL queries during that request:


| key              | value                                                          |
| ---------------- | -------------------------------------------------------------- |
| sql\_query\_time | Cumulative time of all SQL queries during request (in seconds) |

Jira: https://4teamwork.atlassian.net/browse/GEVER-235