### PR TITLE
SQL query logging: Be more defensive in trying to annotate request

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- SQL query logging: Be more defensive in trying to annotate a request
+  that might not always be ready yet (e.g. during testing). [lgraf]
 
 
 1.3.0 (2020-05-19)

--- a/ftw/structlog/sqltime.py
+++ b/ftw/structlog/sqltime.py
@@ -23,8 +23,10 @@ def after_cursor_execute(conn, cursor, statement,
 
     # Track cumulative query execution time in request annotations,
     # for it to be collected later when logging the request.
-    ann = IAnnotations(getRequest())
-    ann['sql_query_time'] = ann.get('sql_query_time', 0) + query_time
+    request = getRequest()
+    if request:
+        ann = IAnnotations(request)
+        ann['sql_query_time'] = ann.get('sql_query_time', 0) + query_time
 
 
 def register_query_profiling_listeners(event):


### PR DESCRIPTION
SQL query logging: Be more defensive in trying to annotate a request that might not always be ready yet (e.g. during testing).

This fixes a test failure that surfaced when attempting to integrate with `opengever.core`:
https://ci.4teamwork.ch/builds/334233/tasks/558628

Jira: https://4teamwork.atlassian.net/browse/GEVER-235