### PR TITLE
Pin tzlocal to version supporting python 2.

### DIFF
--- a/test-plone-4.3.x-sqlalchemy.cfg
+++ b/test-plone-4.3.x-sqlalchemy.cfg
@@ -11,6 +11,8 @@ eggs +=
     zope.sqlalchemy
 
 [versions]
-z3c.saconfig = 0.14
 SQLAlchemy = 1.1.18
+# tzlocal dropped python 2 support in version 3.0b1
+tzlocal = < 3
+z3c.saconfig = 0.14
 zope.sqlalchemy = 0.7.7

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -3,3 +3,7 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
 
 package-name = ftw.structlog
+
+[versions]
+# tzlocal dropped python 2 support in version 3.0b1
+tzlocal = < 3


### PR DESCRIPTION
I have also sorted the pinnings. One could discuss whether `setup.py` would be a better place for this version requirement as the package does not support python3 at all yet.