### PR TITLE
Add support for logging to Fluentd.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,8 +96,18 @@ all SQL queries during that request:
 +----------------+----------------------------------------------------------------+
 
 
-Logfile Location
+Log Destinations
 ----------------
+
+``ftw.structlog`` logs to a file by default, but can be configured to log to a
+Fluentd / Fluent Bit instance instead.
+
+
+Logging to file
+^^^^^^^^^^^^^^^
+
+By default, ``ftw.structlog`` will log to a local file with one JSON object
+per line.
 
 One logfile per Zope2 instance will be created, and its location and name
 will be derived from the instance's eventlog path. If the instance's eventlog
@@ -111,6 +121,17 @@ the root logger.
 
 When running tests in other projects, these errors can be muted by setting the
 environment variable ``FTW_STRUCTLOG_MUTE_SETUP_ERRORS=true``.
+
+Logging to Fluentd
+^^^^^^^^^^^^^^^^^^
+
+If the environment variable ``FLUENT_HOST`` is set, ``ftw.structlog`` will
+log to that fluent host using the Fluentd Forward Protocol, instead of
+logging to a local file. ``FLUENT_HOST`` (optional) allows to specify the
+port, and defaults to 24224 if not set.
+
+Currently, events will be tagged with a static tag ``ftw.structlog``, which
+may be used in Fluentd to route events.
 
 View Name
 ---------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,10 @@ Changelog
 =========
 
 
-1.3.2 (unreleased)
+1.4.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for logging to Fluentd. [lgraf]
 
 
 1.3.1 (2020-05-19)

--- a/ftw/structlog/tests/test_fluent_logging.py
+++ b/ftw/structlog/tests/test_fluent_logging.py
@@ -1,0 +1,30 @@
+from ftw.structlog.testing import STRUCTLOG_FUNCTIONAL_FLUENT
+from ftw.structlog.tests import FunctionalTestCase
+from ftw.testbrowser import browsing
+from mock import patch
+import json
+
+
+class TestFluentLogging(FunctionalTestCase):
+
+    layer = STRUCTLOG_FUNCTIONAL_FLUENT
+
+    @browsing
+    @patch('fluent.handler.FluentHandler.emit')
+    def test_dispatches_to_fluent_handler(self, browser, mock_emit):
+        browser.open(self.portal)
+
+        self.assertEqual(1, mock_emit.call_count)
+        log_record = mock_emit.call_args[0][0]
+
+        self.assertDictContainsSubset({
+            u'status': 200,
+            u'client_ip': u'127.0.0.1',
+            u'bytes': 8133,
+            u'site': u'plone',
+            u'host': u'127.0.0.1',
+            u'referer': u'',
+            u'user': u'Anonymous User',
+            u'view': u'folder_listing',
+            u'method': u'GET',
+        }, json.loads(log_record.msg))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.3.2.dev0'
+version = '1.4.0.dev0'
 
 tests_require = [
     'unittest2',
@@ -47,6 +47,7 @@ setup(name='ftw.structlog',
           'Zope2',
           'pytz',
           'tzlocal',
+          'fluent-logger < 0.10.0',
       ],
       tests_require=tests_require,
       extras_require=dict(tests=tests_require),

--- a/test-plone-4.3.x-sqlalchemy.cfg
+++ b/test-plone-4.3.x-sqlalchemy.cfg
@@ -16,3 +16,4 @@ SQLAlchemy = 1.1.18
 tzlocal = < 3
 z3c.saconfig = 0.14
 zope.sqlalchemy = 0.7.7
+fluent-logger = 0.9.6

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -7,3 +7,4 @@ package-name = ftw.structlog
 [versions]
 # tzlocal dropped python 2 support in version 3.0b1
 tzlocal = < 3
+fluent-logger = 0.9.6


### PR DESCRIPTION
This adds support for logging to a Fluentd / Fluent Bit instance instead of a local file.

By setting the environment variable ``FLUENT_HOST``, ftw.structlog can now be directed to log to that host using the Fluent Forward Protocol.

- Logging is done asynchronously using  `fluent-logger`'s [async handler](https://pypi.org/project/fluent-logger/#asynchronous-communication)
- Events are buffered client side (up to 1MB) if the fluentd instance becomes unavailable
- [Circular queue mode](https://pypi.org/project/fluent-logger/#circular-queue-mode) is not used

Because of this note in`fluent-logger`

> NOTE: please note that it’s important to close the sender or the handler at program termination. This will make sure the communication thread terminates and it’s joined correctly. Otherwise the program won’t exit, waiting for the thread, unless forcibly killed.

I checked that `FluentHandler.close()` is called on application shutdown (CTRL-C), and it does indeed get called by an `atexit` handler that got registered by something (Python logging framework maybe), so we should be good.

### Open questions

- **Tagging** will probably need some thought. Currently, events will be tagged with a static tag `ftw.structlog`. Other log types could conceivably log with a tag like `ftw.contentstats`, and that would allow to use matching rules on the Fluentd side to route those logs into different files. However, once we use this for more than one deployment, we'll probably also need the deployment name as part of the tag.

- **Separation by Pod**: Currently, the default `FluentLogRecordFormatter` will add the container's hostname as `sys_host`. On Kubernetes, this would contain the Pod name, and should allow to match a log event to a particular pod (if that should ever be necessary). I suspect this will rarely be needed in a containerized environment, so that should probably be good enough.

For [CA-5196](https://4teamwork.atlassian.net/browse/CA-5196)