### PR TITLE
Fluentd logging: Use K8s namespace in tag:

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,8 +130,8 @@ log to that fluent host using the Fluentd Forward Protocol, instead of
 logging to a local file. ``FLUENT_HOST`` (optional) allows to specify the
 port, and defaults to 24224 if not set.
 
-Currently, events will be tagged with a static tag ``ftw.structlog``, which
-may be used in Fluentd to route events.
+In order for ftw.structlog to use a proper tag for events logged to Fluentd,
+the Pod namespace needs to be exposed in the ``KUBERNETES_NAMESPACE`` env var.
 
 View Name
 ---------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fluentd logging: Use K8s namespace in tag. [lgraf]
 
 
 1.4.0 (2023-02-01)

--- a/ftw/structlog/logger.py
+++ b/ftw/structlog/logger.py
@@ -36,7 +36,10 @@ def setup_logger():
 def setup_fluent_handler(fluent_host, fluent_port):
     """Set up handler that writes to a Fluentd / Fluent Bit instance.
     """
-    tag = 'ftw.structlog'
+    tag = 'structlog-json.log'
+    ns = os.environ.get('KUBERNETES_NAMESPACE')
+    if ns:
+        tag = '-'.join((ns, tag))
 
     handler = FluentHandler(tag, fluent_host, fluent_port)
     handler.setFormatter(FluentRecordFormatter())

--- a/ftw/structlog/testing.py
+++ b/ftw/structlog/testing.py
@@ -1,6 +1,5 @@
 from App.config import getConfiguration
 from contextlib import contextmanager
-from ftw.structlog.logger import setup_logger
 from ftw.testbrowser import REQUESTS_BROWSER_FIXTURE
 from logging import getLogger
 from plone.app.testing import FunctionalTesting
@@ -24,6 +23,11 @@ def get_log_path():
     if logger.handlers:
         log_path = logger.handlers[0].stream.name
         return log_path
+
+
+def clear_log_handlers():
+    logger = logging.getLogger('ftw.structlog')
+    map(logger.removeHandler, logger.handlers)
 
 
 @contextmanager
@@ -164,15 +168,13 @@ class StructLogFluentLayer(PloneSandboxLayer):
 
     def setUp(self):
         os.environ['FLUENT_HOST'] = 'localhost'
-        setup_logger()
         super(StructLogFluentLayer, self).setUp()
 
     def tearDown(self):
         os.environ.pop('FLUENT_HOST', None)
 
         # Remove any log handlers that were set up
-        logger = logging.getLogger('ftw.structlog')
-        map(logger.removeHandler, logger.handlers)
+        clear_log_handlers()
         super(StructLogFluentLayer, self).tearDown()
 
 

--- a/ftw/structlog/tests/test_fluent_logging.py
+++ b/ftw/structlog/tests/test_fluent_logging.py
@@ -1,3 +1,6 @@
+from ftw.structlog.logger import setup_logger
+from ftw.structlog.testing import clear_log_handlers
+from ftw.structlog.testing import env_var
 from ftw.structlog.testing import STRUCTLOG_FUNCTIONAL_FLUENT
 from ftw.structlog.tests import FunctionalTestCase
 from ftw.testbrowser import browsing
@@ -9,9 +12,25 @@ class TestFluentLogging(FunctionalTestCase):
 
     layer = STRUCTLOG_FUNCTIONAL_FLUENT
 
+    def test_sets_up_tag_including_ns_for_fluent_handler(self):
+        clear_log_handlers()
+
+        with env_var('KUBERNETES_NAMESPACE', 'demo-example-org'):
+            logger = setup_logger()
+        handler = logger.handlers[0]
+        self.assertEqual('demo-example-org-structlog-json.log', handler.tag)
+
+    def test_sets_up_fallback_tag_for_fluent_handler(self):
+        clear_log_handlers()
+
+        logger = setup_logger()
+        handler = logger.handlers[0]
+        self.assertEqual('structlog-json.log', handler.tag)
+
     @browsing
     @patch('fluent.handler.FluentHandler.emit')
     def test_dispatches_to_fluent_handler(self, browser, mock_emit):
+        setup_logger()
         browser.open(self.portal)
 
         self.assertEqual(1, mock_emit.call_count)


### PR DESCRIPTION
This uses the K8s namespace to build the tag that is used for Fluentd logging.

Since this tag is used by the Fluentd file output as the file name, this makes sure the resulting file name is dynamic and logs for deployments in different K8s namespaces are logged to separate files.

In order for this to work, the K8s namespace must be exposed to the container in the env var KUBERNETES_NAMESPACE.

Requires https://github.com/4teamwork/ogg-k8s-apps/pull/4

For [CA-5505](https://4teamwork.atlassian.net/browse/CA-5505)